### PR TITLE
Fix authentication token relaying

### DIFF
--- a/src/main/kotlin/com/dietmap/yaak/domain/userapp/UserAppClient.kt
+++ b/src/main/kotlin/com/dietmap/yaak/domain/userapp/UserAppClient.kt
@@ -4,7 +4,6 @@ import com.dietmap.yaak.api.config.YaakSecurityProperties
 import com.dietmap.yaak.api.config.YaakSecurityType
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -60,7 +59,7 @@ class UserAppClientConfiguration {
 
 
     @Bean
-    @ConditionalOnBean(OAuth2AuthorizedClientManager::class)
+    @ConditionalOnProperty("yaak.security.type", havingValue = "OAUTH")
     @Primary
     fun oauth2AuthorizedWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, securityProperties: YaakSecurityProperties): WebClient {
         val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)


### PR DESCRIPTION
Fix authentication token relaying by replacing @ConditionalOnBean (depending on a bean within the same configuration scope) with @ConditionalOnProperty