### PR TITLE
Add support for Apple App Store status polling

### DIFF
--- a/src/main/kotlin/com/dietmap/yaak/domain/appstore/AppStoreSubscriptionService.kt
+++ b/src/main/kotlin/com/dietmap/yaak/domain/appstore/AppStoreSubscriptionService.kt
@@ -34,7 +34,8 @@ class AppStoreSubscriptionService(val userAppClient: UserAppClient, val appStore
                     transactionId = latestReceiptInfo.transactionId,
                     originalTransactionId = latestReceiptInfo.originalTransactionId,
                     appMarketplace = AppMarketplace.APP_STORE,
-                    expiryTimeMillis = latestReceiptInfo.expiresDateMs
+                    expiryTimeMillis = latestReceiptInfo.expiresDateMs,
+                    appStoreReceipt = subscriptionPurchaseRequest.receipt
             )
 
             return userAppClient.sendSubscriptionNotification(notification)
@@ -61,7 +62,8 @@ class AppStoreSubscriptionService(val userAppClient: UserAppClient, val appStore
                     appMarketplace = AppMarketplace.APP_STORE,
                     expiryTimeMillis = latestReceiptInfo.expiresDateMs,
                     countryCode = null,
-                    currencyCode = null
+                    currencyCode = null,
+                    appStoreReceipt = subscriptionRenewRequest.receipt
             )
 
             return userAppClient.sendSubscriptionNotification(notification)
@@ -155,7 +157,8 @@ class AppStoreSubscriptionService(val userAppClient: UserAppClient, val appStore
                 appMarketplace = AppMarketplace.APP_STORE,
                 expiryTimeMillis = latestReceiptInfo.expiresDateMs,
                 countryCode = null,
-                currencyCode = null
+                currencyCode = null,
+                appStoreReceipt = statusUpdateNotification.latestReceipt
         )
 
         logger.debug("Sending UserAppSubscriptionNotification: $notification")

--- a/src/main/kotlin/com/dietmap/yaak/domain/userapp/UserAppSubscriptionNotification.kt
+++ b/src/main/kotlin/com/dietmap/yaak/domain/userapp/UserAppSubscriptionNotification.kt
@@ -23,7 +23,8 @@ data class UserAppSubscriptionNotification(
         val appMarketplace: AppMarketplace,
         val expiryTimeMillis: Long? = 0,
         val orderingUserId: String? = String(),
-        val discountCode: String? = String()
+        val discountCode: String? = String(),
+        val appStoreReceipt: String? = String()
 )
 
 enum class NotificationType {


### PR DESCRIPTION
Add support for Apple App Store status polling by including receipts in purchase/renewal notifications dispatched to user applications